### PR TITLE
create zip file for binary contents

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -63,10 +63,12 @@ let
     END
   '';
 
-  busybox = packStaticBin "${inp.busybox}/bin/busybox";
+  bwrap = packStaticBin "${inp.bwrap}/bin/bwrap";
+  proot = packStaticBin "${inp.proot}/bin/proot";
+  zstd = packStaticBin "${inp.zstd}/bin/zstd";
 
   # the default nix store contents to extract when first used
-  storeTar = maketar ([ nix ] ++ [ busybox cacert nixpkgsSrc ]);
+  storeTar = maketar ([ cacert nix nixpkgsSrc ]);
 
 
   # The runtime script which unpacks the necessary files to $HOME/.nix-portable
@@ -364,4 +366,8 @@ let
     chmod +x $out/bin/nix-portable
   '';
 in
-nixPortable
+nixPortable.overrideAttrs (prev: {
+  passthru = (prev.passthru or {}) // {
+    inherit bwrap proot;
+  };
+})

--- a/default.nix
+++ b/default.nix
@@ -41,7 +41,7 @@ let
     };
 
   installBin = pkg: bin: ''
-    unzip -qqoj "\''${BASH_SOURCE[0]}" ${ lib.removePrefix "/" "${pkg}/bin/${bin}"} -d \$dir/bin
+    unzip -qqoj "\$self" ${ lib.removePrefix "/" "${pkg}/bin/${bin}"} -d \$dir/bin
     chmod +x \$dir/bin/${bin} # ;
   '';
   installBin2 = pkg: bin: ''
@@ -62,6 +62,9 @@ let
     #!/usr/bin/env bash
 
     set -e
+    set -x
+
+    self="\$(realpath \''${BASH_SOURCE[0]})"
 
     debug(){
       [ -n "\$NP_DEBUG" ] && echo \$@ || true
@@ -208,12 +211,14 @@ let
     )
 
     if [ -n "\$missing" ]; then
+      (
         mkdir -p \$dir/tmp \$dir/store/
         rm -rf \$dir/tmp/*
         cd \$dir/tmp
-        unzip -qqp "\''${BASH_SOURCE[0]}" ${ lib.removePrefix "/" "${storeTar}/tar"} \
+        unzip -qqp "\$self" ${ lib.removePrefix "/" "${storeTar}/tar"} \
          | tar -xJ \$missing --strip-components 2
         mv \$dir/tmp/* \$dir/store/
+      )
     fi
 
     PATH="\$PATH_OLD"

--- a/flake.nix
+++ b/flake.nix
@@ -32,14 +32,15 @@
               patches = (_.patches or []) ++ [ ./nix-nfs.patch ];
             });
 
-            busybox = pkgsCached.busybox;
-            compression = "xz -1 -T $(nproc)";
+            busybox = pkgs.pkgsStatic.busybox;
+            compression = "zstd -18 -T0";
             gnutar = pkgs.pkgsStatic.gnutar;
             lib = inp.nixpkgs.lib;
             mkDerivation = pkgs.stdenv.mkDerivation;
             nixpkgsSrc = pkgs.path;
             perl = pkgs.pkgsBuildBuild.perl;
             xz = pkgs.pkgsStatic.xz;
+            zstd = pkgs.pkgsStatic.zstd;
           };
 
   in


### PR DESCRIPTION
By appending a ZIP structure to the end of the shell script, we can add the binaries with zip to the end, and later extract them with unzip. This saves bash from having to interpret each base64 line and reduces the size somewhat. There are some considerations with requiring more utilities to be present on the target machine, and this is still just a PoC.

- Performance: `time ./result/bin/nix-portable nix run nixpkgs#hello` from 0.7s to 0.2s.
- SIze: 57M to 41M