### PR TITLE
Fix bwrap detection

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -127,7 +127,7 @@ let
     debug "proot executable: \$NP_PROOT"
     if [ -z "\$NP_RUNTIME" ]; then
       # check if bwrap works properly
-      if \$NP_BWRAP --bind / / --bind ${busybox}/bin/busybox \$HOME/testxyz/true \$HOME/testxyz/true 2>/dev/null; then
+      if \$NP_BWRAP --bind / / --bind \$dir/store /nix/store ${busybox}/bin/busybox true 2>/dev/null; then
         debug "bwrap seems to work on this system -> will use bwrap"
         NP_RUNTIME=bwrap
       else


### PR DESCRIPTION
When checking for `bwrap`, bind `$NP_LOCATION/.nix-portable/store/...`to `/nix/store` and execute busybox from there.

The previous check would try to bind host's `/nix/store/...-busybox` which would mostly fail unless the host already has exactly the same derivation built.