### PR TITLE
Default to using the installed git and add environment variables NP_GIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ In case the automatically selected runtime doesn't work, use the follwing enviro
 The following environment variables are optional and can be used to override the default behaviour of nix-portable
 ```
 NP_DEBUG      (1 = debug msgs; 2 = 'set -e' for nix-portable)
-NP_MINIMAL    do not automatically install git
+NP_GIT        specify path to the git executable
 NP_LOCATION   where to put the `.nix-portable` dir. (defaults to `$HOME`)
 NP_RUNTIME    which runtime to use (must be 'bwrap' or 'proot') 
 NP_BWRAP      specify the path to the bwrap executable to use


### PR DESCRIPTION
This change make nix-portable install and override `git` by default, unless users specify the path to git executable with the environment variable `NP_GIT`.

When nix-portable runs in an environment where the Git version is not compatible (v1.x, etc.), flake-related commands would error out:

```console
$ nix-portable nix flake info
Unknown option: -C
usage: git [--version] [--help] [-c name=value]
           [--exec-path[=<path>]] [--html-path] [--man-path] [--info-path]
           [-p|--paginate|--no-pager] [--no-replace-objects] [--bare]
           [--git-dir=<path>] [--work-tree=<path>] [--namespace=<name>]
           <command> [<args>]
error: --- Error ---------------------------------------- nix
program 'git' failed with exit code 129
```

If applied, the error will be fixed:

```console
$ nix-portable nix flake info
Resolved URL:  git+file:///afs/cern.ch/work/y/yuehshun/private/Projects/DavHau/nix-portable
Locked URL:    git+file:///afs/cern.ch/work/y/yuehshun/private/Projects/DavHau/nix-portable?ref=force-install-git&rev=b517129db9317af9ace7283b14a11a0ef73e2dbd
Path:          /nix/store/j75mrqgbz28kjdc6xms7s5cgh50qbf5x-source
Revision:      b517129db9317af9ace7283b14a11a0ef73e2dbd
Revisions:     52
Last modified: 2022-01-21 03:22:54
```