### PR TITLE
Don't exit when bind mounting `/etc/ssl`

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ In case the automatically selected runtime doesn't work, use the follwing enviro
 ### Environment Variables
 The following environment variables are optional and can be used to override the default behaviour of nix-portable
 ```
-NP_DEBUG      (1 = debug msgs; 2 = 'set -e' for nix-portable)
+NP_DEBUG      (1 = debug msgs; 2 = 'set -x' for nix-portable)
 NP_GIT        specify path to the git executable
 NP_LOCATION   where to put the `.nix-portable` dir. (defaults to `$HOME`)
 NP_RUNTIME    which runtime to use (must be 'bwrap' or 'proot')

--- a/default.nix
+++ b/default.nix
@@ -212,7 +212,7 @@ let
       sslBind="\$(realpath \$SSL_CERT_FILE) \$dir/ca-bundle.crt"
       export SSL_CERT_FILE="\$dir/ca-bundle.crt"
     else
-      sslBind=/etc/ssl
+      sslBind="/etc/ssl /etc/ssl"
     fi
 
 
@@ -293,7 +293,7 @@ let
       while :; do
         if [ -n "\$1" ]; then
           from="\$1"; shift
-          to="\$1"; shift
+          to="\$1"; shift || { echo "no bind destination provided for \$from!"; exit 3; }
           binds="\$binds \$arg \$from\$sep\$to";
         else
           break


### PR DESCRIPTION
When `nix-portable` falls back to using `/etc/ssl` it sets `$sslBind` [to a single path](https://github.com/DavHau/nix-portable/blob/a53a3f3f2262f38fc3c020b21acc6d7677ed9516/default.nix#L215) instead of a from/to pair. 

When processing this bind, `makeBindArgs`, expecting pairs, [unconditionally calls `shift` twice](https://github.com/DavHau/nix-portable/blob/a53a3f3f2262f38fc3c020b21acc6d7677ed9516/default.nix#L296) causing the script to exit with no error message (since `set -e` is specificed).

This PR sets `sslBind` to `/etc/ssl /etc/ssl` in this case and has `makeBindArgs` print out an error.