### PR TITLE
Handle whitespace in Bash variables.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -197,10 +197,10 @@ let
     if [ -z "\$SSL_CERT_FILE" ]; then
       debug "SSL_CERT_FILE not defined. trying to find certs automatically"
       if [ -e /etc/ssl/certs/ca-bundle.crt ]; then
-        export SSL_CERT_FILE=\$(realpath /etc/ssl/certs/ca-bundle.crt)
+        export SSL_CERT_FILE="\$(realpath /etc/ssl/certs/ca-bundle.crt)"
         debug "found /etc/ssl/certs/ca-bundle.crt with real path \$SSL_CERT_FILE"
       elif [ -e /etc/ssl/certs/ca-certificates.crt ]; then
-        export SSL_CERT_FILE=\$(realpath /etc/ssl/certs/ca-certificates.crt)
+        export SSL_CERT_FILE="\$(realpath /etc/ssl/certs/ca-certificates.crt)"
         debug "found /etc/ssl/certs/ca-certificates.crt with real path \$SSL_CERT_FILE"
       elif [ ! -e /etc/ssl/certs ]; then
         debug "/etc/ssl/certs does not exist. Will use certs from nixpkgs."
@@ -232,7 +232,7 @@ let
 
 
     storePathOfFile(){
-      file=\$(realpath \$1)
+      file="\$(realpath \$1)"
       sPath="\$(echo "\$file" | awk -F "/" 'BEGIN{OFS="/";}{print \$2,\$3,\$4}')"
       echo "/\$sPath"
     }
@@ -248,10 +248,10 @@ let
       find / -mindepth 1 -maxdepth 1 -not -name nix -not -name dev |
       while read p; do
         if [ -e "\$p" ]; then
-          real=\$(realpath "\$p")
+          real="\$(realpath "\$p")"
           if [ -e "\$real" ]; then
             if [[ "\$real" == /nix/store/* ]]; then
-              storePath=\$(storePathOfFile "\$real")
+              storePath="\$(storePathOfFile "\$real")"
               toBind=("\''${toBind[@]}" "\$storePath" "\$storePath")
             else
               toBind=("\''${toBind[@]}" "\$real" "\$p")
@@ -266,10 +266,10 @@ let
 
       for p in "\''${paths[@]}"; do
         if [ -e "\$p" ]; then
-          real=\$(realpath "\$p")
+          real="\$(realpath "\$p")"
           if [ -e "\$real" ]; then
             if [[ "\$real" == /nix/store/* ]]; then
-              storePath=\$(storePathOfFile "\$real")
+              storePath="\$(storePathOfFile "\$real")"
               toBind=("\''${toBind[@]}" "\$storePath" "\$storePath")
             else
               toBind=("\''${toBind[@]}" "\$real" "\$real")
@@ -306,10 +306,10 @@ let
 
     ### select container runtime
     debug "figuring out which runtime to use"
-    [ -z "\$NP_BWRAP" ] && NP_BWRAP=\$(PATH="\$PATH_OLD:\$PATH" which bwrap 2>/dev/null) || true
+    [ -z "\$NP_BWRAP" ] && NP_BWRAP="\$(PATH="\$PATH_OLD:\$PATH" which bwrap 2>/dev/null)" || true
     [ -z "\$NP_BWRAP" ] && NP_BWRAP="\$dir"/bin/bwrap
     debug "bwrap executable: \$NP_BWRAP"
-    [ -z "\$NP_PROOT" ] && NP_PROOT=\$(PATH="\$PATH_OLD:\$PATH" which proot 2>/dev/null) || true
+    [ -z "\$NP_PROOT" ] && NP_PROOT="\$(PATH="\$PATH_OLD:\$PATH" which proot 2>/dev/null)" || true
     [ -z "\$NP_PROOT" ] && NP_PROOT="\$dir"/bin/proot
     debug "proot executable: \$NP_PROOT"
     if [ -z "\$NP_RUNTIME" ]; then
@@ -361,13 +361,13 @@ let
     index="$(cat ${storeTar}/index)"
     # TODO: Escape/quote this— *Probably* `cat \''${storeTar}/index | while read path; do`? (I'm not sure if the output is line-separated.)
 
-    export missing=\$(
+    export missing="\$(
       for path in \$index; do
-        if [ ! -e "\$dir"/store/\$(basename "\$path") ]; then
+        if [ ! -e "\$dir/store/\$(basename "\$path")" ]; then
           echo "nix/store/\$(basename "\$path")"
         fi
       done
-    )
+    )"
 
     if [ -n "\$missing" ]; then
       debug "extracting missing store paths"
@@ -415,7 +415,7 @@ let
 
 
     ### check which runtime has been used previously
-    lastRuntime=\$(cat "\$dir/conf/last_runtime" 2>&3) || true
+    lastRuntime="\$(cat "\$dir/conf/last_runtime" 2>&3)" || true
 
 
 

--- a/default.nix
+++ b/default.nix
@@ -132,7 +132,7 @@ let
 
 
     create_nix_conf(){
-      sandbox=\$1
+      sandbox="\$1"
 
       mkdir -p "\$dir"/conf/
       rm -f "\$dir"/conf/nix.conf
@@ -232,8 +232,8 @@ let
 
 
     storePathOfFile(){
-      file="\$(realpath \$1)"
-      sPath="\$(echo "\$file" | awk -F "/" 'BEGIN{OFS="/";}{print \$2,\$3,\$4}')"
+      file="\$(realpath "\$1")"
+      sPath="\$(echo "\$file" | awk -F "/" 'BEGIN{OFS="/";}{print "\$2,\$3,\$4"}')"
       echo "/\$sPath"
     }
 
@@ -288,8 +288,8 @@ let
 
 
     makeBindArgs(){
-      arg=\$1; shift
-      sep=\$1; shift
+      arg="\$1"; shift
+      sep="\$1"; shift
       binds=()
       while :; do
         if [ -n "\$1" ]; then
@@ -396,20 +396,20 @@ let
     ### select executable
     # the executable can either be selected by executing './nix-portable BIN_NAME',
     # or by symlinking to nix-portable, in which case the name of the symlink selectes the binary
-    if [[ "\$(basename \$0)" == nix-portable* ]]; then
+    if [[ "\$(basename "\$0")" == nix-portable* ]]; then
       if [ -z "\$1" ]; then
         echo "Error: please specify the nix binary to execute"
         echo "Alternatively symlink against \$0"
         exit 1
       elif [ "\$1" == "debug" ]; then
-        bin="\$(which \$2)"
+        bin="\$(which "\$2")"
         shift; shift
       else
         bin="\$dir/store${lib.removePrefix "/nix/store" nix}/bin/\$1"
         shift
       fi
     else
-      bin="\$dir/store${lib.removePrefix "/nix/store" nix}/bin/\$(basename \$0)"
+      bin="\$dir/store${lib.removePrefix "/nix/store" nix}/bin/\$(basename "\$0")"
     fi
 
 

--- a/default.nix
+++ b/default.nix
@@ -326,22 +326,22 @@ let
     if [ "\$NP_RUNTIME" == "bwrap" ]; then
       collectBinds
       makeBindArgs --bind " " \$toBind \$sslBind
-      run="\$NP_BWRAP \$BWRAP_ARGS \\
-        --bind \$dir/emptyroot /\\
+      run="\''${NP_BWRAP@Q} \$BWRAP_ARGS \\
+        --bind \''${dir@Q}/emptyroot /\\
         --dev-bind /dev /dev\\
-        --bind \$dir/ /nix\\
+        --bind \''${dir@Q}/ /nix\\
         \$binds"
-        # --bind \$dir/busybox/bin/busybox /bin/sh\\
+        # --bind \''${dir@Q}/busybox/bin/busybox /bin/sh\\
     else
       # proot
       collectBinds
       makeBindArgs -b ":" \$toBind \$sslBind
-      run="\$NP_PROOT \$PROOT_ARGS\\
-        -r \$dir/emptyroot\\
+      run="\''${NP_PROOT@Q} \$PROOT_ARGS\\
+        -r \''${dir@Q}/emptyroot\\
         -b /dev:/dev\\
-        -b \$dir/store:/nix/store\\
+        -b \''${dir@Q}/store:/nix/store\\
         \$binds"
-        # -b \$dir/busybox/bin/busybox:/bin/sh\\
+        # -b \''${dir@Q}/busybox/bin/busybox:/bin/sh\\
     fi
     debug "base command will be: \$run"
 
@@ -384,7 +384,7 @@ let
     if [ -n "\$missing" ]; then
       debug "registering new store paths to DB"
       reg="$(cat ${storeTar}/closureInfo/registration)"
-      cmd="\$run \$dir/store${lib.removePrefix "/nix/store" nix}/bin/nix-store --load-db"
+      cmd="\$run \''${dir@Q}/store${lib.removePrefix "/nix/store" nix}/bin/nix-store --load-db"
       debug "running command: \$cmd"
       echo "\$reg" | "\$cmd"
     fi
@@ -481,7 +481,7 @@ let
       debug "running command: \$NP_RUN \$bin \$@"
       exec "\$NP_RUN" "\$bin" "\$@"
     else
-      cmd="\$NP_RUN \$bin \$@"
+      cmd="\''${NP_RUN@Q} \''${bin@Q} \$@"
       debug "running command: \$cmd"
       exec "\$NP_RUN" "\$bin" "\$@"
     fi


### PR DESCRIPTION
See commit list for summary of the types of changes.

Attempts to close #44.

In theory I think this is everything that would need to be done.

**However, note that this currently breaks `nix-portable`** with `nix/store/zbabf0j2wibf6y74xyz80im3m2jk9bmn-libssh2-1.10.0: not found in archive`.

I've elected not to further pursue this option in the application that I originally intended to use it for, so the best I can do is to offer this PR as-is for consideration.

Hopefully the remaining problems will be obvious and easily fixed by somebody more familiar with the inner workings of Nix and `nix-portable`, but perhaps not.