### PR TITLE
Update to nixpgks 22.11 & fix test suite

### DIFF
--- a/.github/workflows/nix-portable.yml
+++ b/.github/workflows/nix-portable.yml
@@ -23,10 +23,8 @@ jobs:
 
     - uses: cachix/install-nix-action@v19
       with:
-        install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20201221_9fab14a/install
         extra_nix_config: |
           experimental-features = nix-command flakes
-          extra-platforms = ${{ matrix.system }}
 
     - uses: cachix/cachix-action@v12
       with:
@@ -42,7 +40,7 @@ jobs:
     - name: Install binfmt support
       run: sudo apt-get install -y
 
-    - run: 'nix build -L .#defaultPackage.${{ matrix.system }}'
+    - run: 'nix build -L .#defaultPackage.${{ matrix.system }} --extra-platforms "${{ matrix.system }}"'
 
     - name: Archive result
       uses: actions/upload-artifact@v3

--- a/.github/workflows/nix-portable.yml
+++ b/.github/workflows/nix-portable.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         system: [ x86_64-linux, aarch64-linux ]
 
@@ -56,6 +57,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         # qemu_os: [ arch, centos7, centos8, debian, nixos, ubuntu ]
         # TODO: fix and re-activate tests

--- a/.github/workflows/nix-portable.yml
+++ b/.github/workflows/nix-portable.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   workflow_dispatch:
   push:
-    branches: [ "*" ]
+    branches: [ "ci" ]
 jobs:
 
 
@@ -28,6 +28,7 @@ jobs:
       with:
         extra_nix_config: |
           experimental-features = nix-command flakes
+          extra-platforms = ${{ matrix.system }}
 
     - uses: cachix/cachix-action@v12
       with:
@@ -43,7 +44,7 @@ jobs:
     - name: Install binfmt support
       run: sudo apt-get install -y
 
-    - run: 'nix build -L .#defaultPackage.${{ matrix.system }} --extra-platforms "${{ matrix.system }}"'
+    - run: 'nix build -L .#defaultPackage.${{ matrix.system }}'
 
     - name: Archive result
       uses: actions/upload-artifact@v3
@@ -55,7 +56,7 @@ jobs:
 
 
   test_qemu:
-    name: Test on distro via qemu
+    name: Test via qemu
     needs: build
     if: true
     runs-on: ubuntu-latest
@@ -63,9 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # qemu_os: [ arch, centos7, centos8, debian, nixos, ubuntu ]
-        # TODO: fix and re-activate tests
-        qemu_os: [ centos7, debian, ubuntu, debian-aarch64 ]
+        qemu_os: [ arch, centos7, debian, fedora, nixos, ubuntu, debian-aarch64 ]
     steps:
 
     - uses: actions/checkout@v3
@@ -86,6 +85,37 @@ jobs:
 
     - run: 'nix run -L .#job-qemu-${{ matrix.qemu_os }}'
 
+
+
+  test_nix-static:
+    name: Test nix-static via qemu
+    needs: build
+    if: true
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        qemu_os: [ arch, centos7, debian, fedora, nixos, ubuntu, debian-aarch64 ]
+    steps:
+
+    - uses: actions/checkout@v3
+      with:
+          # Nix Flakes doesn't work on shallow clones
+          fetch-depth: 0
+
+    - uses: cachix/install-nix-action@v19
+      with:
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+          extra-platforms = ${{ matrix.system }}
+
+    - uses: cachix/cachix-action@v12
+      with:
+        name: nix-portable
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+    - run: 'nix run -L .#job-qemu-${{ matrix.qemu_os }}-nix-static'
 
 
   test_docker:

--- a/.github/workflows/nix-portable.yml
+++ b/.github/workflows/nix-portable.yml
@@ -57,6 +57,7 @@ jobs:
   test_qemu:
     name: Test on distro via qemu
     needs: build
+    if: true
     runs-on: ubuntu-latest
     continue-on-error: true
     strategy:
@@ -91,6 +92,7 @@ jobs:
   test_docker:
     name: Test inside docker container
     needs: build
+    if: true
     runs-on: ubuntu-latest
     steps:
 
@@ -116,6 +118,7 @@ jobs:
   test_github:
     name: Test inside github action
     needs: build
+    if: true
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/nix-portable.yml
+++ b/.github/workflows/nix-portable.yml
@@ -75,7 +75,6 @@ jobs:
 
     - uses: cachix/install-nix-action@v19
       with:
-        install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20201221_9fab14a/install
         extra_nix_config: |
           experimental-features = nix-command flakes
           extra-platforms = ${{ matrix.system }}
@@ -103,7 +102,6 @@ jobs:
 
     - uses: cachix/install-nix-action@v19
       with:
-        install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20201221_9fab14a/install
         extra_nix_config: |
           experimental-features = nix-command flakes
 
@@ -129,7 +127,6 @@ jobs:
 
     - uses: cachix/install-nix-action@v19
       with:
-        install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20201221_9fab14a/install
         extra_nix_config: |
           experimental-features = nix-command flakes
 

--- a/.github/workflows/nix-portable.yml
+++ b/.github/workflows/nix-portable.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      continue-on-error: true
       matrix:
         system: [ x86_64-linux, aarch64-linux ]
 
@@ -58,6 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      continue-on-error: true
       matrix:
         # qemu_os: [ arch, centos7, centos8, debian, nixos, ubuntu ]
         # TODO: fix and re-activate tests

--- a/.github/workflows/nix-portable.yml
+++ b/.github/workflows/nix-portable.yml
@@ -2,6 +2,7 @@
 name: "build and test"
 on:
   pull_request:
+  workflow_dispatch:
   push:
     branches: [ "*" ]
 jobs:
@@ -10,9 +11,9 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       fail-fast: false
-      continue-on-error: true
       matrix:
         system: [ x86_64-linux, aarch64-linux ]
 
@@ -57,9 +58,9 @@ jobs:
     name: Test on distro via qemu
     needs: build
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       fail-fast: false
-      continue-on-error: true
       matrix:
         # qemu_os: [ arch, centos7, centos8, debian, nixos, ubuntu ]
         # TODO: fix and re-activate tests

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ result*
 vm/
 .direnv/
 img
+QEMU_EFI.img

--- a/default.nix
+++ b/default.nix
@@ -113,7 +113,8 @@ let
     # user specified location for program files and nix store
     [ -z "\$NP_LOCATION" ] && NP_LOCATION="\$HOME"
     dir="\$NP_LOCATION/.nix-portable"
-    mkdir -p \$dir/bin
+    # create /nix/var/nix to prevent nix from falling back to chroot store.
+    mkdir -p \$dir/{bin,var/nix/var}
     # santize the tmpbin directory
     rm -rf "\$dir/tmpbin"
     # create a directory to hold executable symlinks for overriding
@@ -321,7 +322,7 @@ let
         NP_RUNTIME=proot
       fi
     else
-      debug "runtime selected via NP_RUNTIME : \$NP_RUNTIME"
+      debug "runtime selected via NP_RUNTIME: \$NP_RUNTIME"
     fi
     if [ "\$NP_RUNTIME" == "bwrap" ]; then
       collectBinds
@@ -339,7 +340,7 @@ let
       run="\$NP_PROOT \$PROOT_ARGS\\
         -r \$dir/emptyroot\\
         -b /dev:/dev\\
-        -b \$dir/store:/nix/store\\
+        -b \$dir:/nix\\
         \$binds"
         # -b \$dir/busybox/bin/busybox:/bin/sh\\
     fi

--- a/flake.lock
+++ b/flake.lock
@@ -53,11 +53,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677203921,
-        "narHash": "sha256-T6Oy48mBDhKKXn7nrt/Frtg4mDvjjg81A4jFr4GJTvs=",
+        "lastModified": 1670461440,
+        "narHash": "sha256-jy1LB8HOMKGJEGXgzFRLDU1CBGL0/LlkolgnqIsF0D8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6a54ea90f1e0a3422fb0ba49694d977c9b430af3",
+        "rev": "04a75b2eecc0acf6239acf9dd04485ff8d14f425",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "defaultChannel": {
       "locked": {
-        "lastModified": 1635350005,
-        "narHash": "sha256-tAMJnUwfaDEB2aa31jGcu7R7bzGELM9noc91L2PbVjg=",
+        "lastModified": 1677179781,
+        "narHash": "sha256-+peLp16ruWLuTFHo0ZUbLlS1/meS/+RsWQQ9bUAzOh8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1c1f5649bb9c1b0d98637c8c365228f57126f361",
+        "rev": "50c23cd4ff6c8344e0b4d438b027b3afabfe58dd",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-20.09",
+        "ref": "nixos-22.11",
         "type": "indirect"
       }
     },
@@ -34,44 +34,62 @@
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1639739069,
-        "narHash": "sha256-GOsiqy9EaTwDn2PLZ4eFj1VkXcBUbqrqHehRE9GuGdU=",
+        "lastModified": 1674678482,
+        "narHash": "sha256-MtVatZVsV+dtjdD4AC4bztrnDFas+WZYHzQMt41FwzU=",
         "owner": "NixOS",
         "repo": "nix",
-        "rev": "b4f250417ab64f237c8b51439fe1f427193ab23b",
+        "rev": "435a16b5556f4171b4204a3f65c9dedf215f168c",
         "type": "github"
       },
       "original": {
         "id": "nix",
-        "ref": "2.5.1",
+        "ref": "2.13.2",
         "type": "indirect"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1642798845,
-        "narHash": "sha256-1g1X3wKmroGix68OXwb4gR1yXKPQ36apI1dssd/YbuM=",
+        "lastModified": 1677203921,
+        "narHash": "sha256-T6Oy48mBDhKKXn7nrt/Frtg4mDvjjg81A4jFr4GJTvs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e84444b14cc75a4be17b58fd2c344f47dddf084e",
+        "rev": "6a54ea90f1e0a3422fb0ba49694d977c9b430af3",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-21.11",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixos-22.11-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
       }
     },
     "root": {
       "inputs": {
         "defaultChannel": "defaultChannel",
         "nix": "nix",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "defaultChannel"
+        ]
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -122,7 +122,6 @@
         let
           pkgsDefaultChannel = import inp.defaultChannel { inherit system crossSystem; };
           pkgs = import inp.nixpkgs { inherit system crossSystem; };
-          pkgsCached = if crossSystem == null then pkgs else import inp.nixpkgs { system = crossSystem; };
 
           # the static proot built with nix somehow didn't work on other systems,
           # therefore using the proot static build from proot gitlab
@@ -291,11 +290,10 @@
                       # test some nix commands
                       set -e
                       $scp -r ${inp.nix.packages."${system}".nix-static}/bin test@localhost:/home/test/nix-static
-                      $scp -r ${pkgs.gitMinimal}/bin test@localhost:/home/test/git
-                      ${concatStringsSep "\n\n" (flip map commandsToTest (cmd: ''
+                      ${concatStringsSep "\n\n" (flip map (tail commandsToTest) (cmd: ''
                         echo "testing cmd: ${escape cmd}"
                         NIX_PATH="nixpkgs=https://github.com/nixos/nixpkgs/tarball/${inp.defaultChannel.rev}"
-                        $ssh "NIX_PATH=$NIX_PATH PATH=\$PATH:\$HOME/git \$HOME/nix-static/${escape cmd} --extra-experimental-features 'nix-command flakes'"
+                        $ssh "NIX_PATH=$NIX_PATH PATH= \$HOME/nix-static/${escape cmd} --extra-experimental-features 'nix-command flakes'"
                       ''
                       ))}
                     ''}

--- a/testing/qemu-efi.nix
+++ b/testing/qemu-efi.nix
@@ -8,8 +8,8 @@
 
 let
   qemu-efi-gz = fetchurl {
-    url = "http://snapshots.linaro.org/components/kernel/leg-virt-tianocore-edk2-upstream/4443/QEMU-AARCH64/RELEASE_GCC5/QEMU_EFI.img.gz";
-    sha256 = "sha256-bOO6bsiwHaf39TWdkxOYWOw9p+/EzCkZLzi5YQPZTLY=";
+    url = "http://snapshots.linaro.org/components/kernel/leg-virt-tianocore-edk2-upstream/4801/QEMU-AARCH64/RELEASE_GCC5/QEMU_EFI.img.gz";
+    sha256 = "sha256-Rfio8FtcXrVslz+W6BsSV0xHvxwHLfqGhJMs2Kc3B30=";
   };
 in
 


### PR DESCRIPTION
- update nixpkgs to 22.11
- update nix to 2.13.2
- create /nix/var/nix to prevent nix from falling back to chroot store
- add tests using `nix#nix-static` instead of `nix-portable` to see how we compare to it
- remove tests for centos8
- add tests for fedora
- re-enable tests for nixos

using proot as a runtime triggers a problem on `arch`, `nixos`, `fedora` and inside `docker` containers.
For arch, nixos, fedora it is not an issue, because nix-portable will use bubblewrap on theses systems by default anyways.
But for docker it is currently a blocker

The error:
```
hello> unpacking sources
hello> unpacking source archive /nix/store/pa10z4ngm0g83kx9mssrqzz30s84vq7k-hello-2.12.1.tar.gz
hello> source root is hello-2.12.1
hello> setting SOURCE_DATE_EPOCH to timestamp 1653865426 of file hello-2.12.1/ChangeLog
hello> patching sources
hello> configuring
hello> no configure script, doing nothing
hello> building
hello> build flags: SHELL=/nix/store/zcla0ljiwpg5w8pvfagfjq1y2vasfix5-bash-5.1-p16/bin/bash
hello> There seems to be no Makefile in this directory.
hello> You must run ./configure before running 'make'.
hello> make: *** [GNUmakefile:108: abort-due-to-no-makefile] Error 1
error: builder for '/nix/store/2rymqf3xf6qknxvpbc46jssnli8xsskg-hello-2.12.1.drv' failed with exit code 2
```
@Mic92 