### PR TITLE
Follow a linked NP_LOCATION

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -112,6 +112,7 @@ let
 
     # user specified location for program files and nix store
     [ -z "\$NP_LOCATION" ] && NP_LOCATION="\$HOME"
+    NP_LOCATION="\$(readlink -f "\$NP_LOCATION")"
     dir="\$NP_LOCATION/.nix-portable"
     # create /nix/var/nix to prevent nix from falling back to chroot store.
     mkdir -p \$dir/{bin,var/nix/var}


### PR DESCRIPTION
Aims to fix #75.

If `$NP_LOCATION` is linked to a location `broot` will fail to start. This dereferences any link in `$NP_LOCATION`. I have not tested it beyond confirming that it works on my local machine and my HPC cluster.