### PR TITLE
new runtime: nix --store

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,55 +31,55 @@
         "type": "github"
       }
     },
-    "lowdown-src": {
+    "libgit2": {
       "flake": false,
       "locked": {
-        "lastModified": 1633514407,
-        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "lastModified": 1697646580,
+        "narHash": "sha256-oX4Z3S9WtJlwvj0uH9HlYcWv+x1hqp8mhXl7HsLu2f0=",
+        "owner": "libgit2",
+        "repo": "libgit2",
+        "rev": "45fd9ed7ae1a9b74b957ef4f337bc3c8b3df01b5",
         "type": "github"
       },
       "original": {
-        "owner": "kristapsdz",
-        "repo": "lowdown",
+        "owner": "libgit2",
+        "repo": "libgit2",
         "type": "github"
       }
     },
     "nix": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "lowdown-src": "lowdown-src",
+        "libgit2": "libgit2",
         "nixpkgs": "nixpkgs",
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1695206941,
-        "narHash": "sha256-ggISAuGpTkKp6JXt1BbcLtLDYOPECWqrVnPVgQEFHYc=",
+        "lastModified": 1712163141,
+        "narHash": "sha256-BSl8Jijq1A4n1ToQy0t0jDJCXhJK+w1prL8QMHS5t54=",
         "owner": "NixOS",
         "repo": "nix",
-        "rev": "44fb1192185cdd03343da7faa08a1c605f773419",
+        "rev": "7bc4af7301df34ea4e157338ac3792c1a9ae35b7",
         "type": "github"
       },
       "original": {
         "id": "nix",
-        "ref": "2.18.0",
+        "ref": "2.20.6",
         "type": "indirect"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1695124524,
-        "narHash": "sha256-trXDytVCqf3KryQQQrHOZKUabu1/lB8/ndOAuZKQrOE=",
-        "owner": "edolstra",
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a3d30b525535e3158221abc1a957ce798ab159fe",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
-        "ref": "fix-aws-sdk-cpp",
+        "owner": "NixOS",
+        "ref": "nixos-23.05-small",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     # Error: checking whether build environment is sane... ls: cannot access './configure': No such file or directory
     defaultChannel.url = "nixpkgs/nixos-unstable";
 
-    nix.url = "nix/2.18.0";
+    nix.url = "nix/2.20.6";
   };
 
   outputs = { self, ... }@inp:
@@ -54,14 +54,14 @@
           url = "https://cloud.centos.org/altarch/7/images/CentOS-7-x86_64-GenericCloud-2009.qcow2c";
           sha256 = "09wqzlhb858qm548ak4jj4adchxn7rgf5fq778hrc52rjqym393v";
           # user namespaces are disabled on centos 7
-          excludeRuntimes = [ "bwrap" ];
+          excludeRuntimes = [ "nix" "bwrap" ];
         };
         debian = {
           system = "x86_64-linux";
           url = "https://cdimage.debian.org/cdimage/openstack/archive/10.9.0/debian-10.9.0-openstack-amd64.qcow2";
           sha256 = "0mf9k3pgzighibly1sy3cjq7c761r3akp8mlgd878lwf006vqrky";
           # permissions for user namespaces not enabled by default
-          excludeRuntimes = [ "bwrap" ];
+          excludeRuntimes = [ "nix" "bwrap" ];
         };
         fedora = {
           system = "x86_64-linux";
@@ -114,7 +114,7 @@
           url = "https://cdimage.debian.org/cdimage/openstack/archive/10.9.0/debian-10.9.0-openstack-arm64.qcow2";
           sha256 = "0mz868j1k8jwhgg9a21dv7dr4rsy1bhklbqqw3qig06acy0vg8yi";
           # permissions for user namespaces not enabled by default
-          excludeRuntimes = [ "bwrap" ];
+          excludeRuntimes = [ "nix" "bwrap" ];
         };
       };
 
@@ -148,7 +148,9 @@
             lib = inp.nixpkgs.lib;
             compression = "zstd -3 -T1";
 
-            nix = inp.nix.packages."${system}".nix;
+            nix = inp.nix.packages.${system}.nix;
+            nixRev = inp.nix.rev;
+            nixStatic = inp.nix.packages.${system}.nix-static;
 
             busybox = pkgs.pkgsStatic.busybox;
             bwrap = pkgs.pkgsStatic.bubblewrap;
@@ -190,7 +192,7 @@
             makeQemuPipelines = mode: mapAttrs' (os: img: let
               debug = mode == "debug";
               suffix = if mode == "normal" then "" else "-${mode}";
-              runtimes = filter (runtime: ! elem runtime (testImages."${os}".excludeRuntimes or []) ) [ "bwrap" "proot" ];
+              runtimes = filter (runtime: ! elem runtime (testImages."${os}".excludeRuntimes or []) ) [ "nix" "bwrap" "proot" ];
               img =
                 if testImages."${os}" ? img then testImages."${os}".img
                 else fetchurl { inherit (testImages."${os}") url sha256 ;};


### PR DESCRIPTION
This adds a new runtime named `nix` besides `bwrap` and `proot`.
This runtime is based on a static nix, utilizing the nix native chroot store feature to bind mount `$HOME/.nix-portable/nix` to `/nix`.

The new runtime priority order:
- nix
- bwrap
- proot