### PR TITLE
add support for latest ubuntu versions

### DIFF
--- a/.github/workflows/nix-portable.yml
+++ b/.github/workflows/nix-portable.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        qemu_os: [ arch, centos7, debian, fedora, nixos, ubuntu, debian-aarch64 ]
+        qemu_os: [ arch, centos7, debian, fedora, nixos, ubuntu_22_04, ubuntu_23_10, ubuntu_24_04, debian-aarch64 ]
     steps:
 
     - uses: actions/checkout@v4

--- a/proot/alpine.nix
+++ b/proot/alpine.nix
@@ -1,12 +1,26 @@
 {
   pkgs ? import <nixpkgs> {},
   ...
-}:
-
+}: let
+system = pkgs.system;
+apks = {
+  x86_64-linux = {
+    # original: http://dl-cdn.alpinelinux.org/alpine/edge/testing/x86_64/proot-static-5.4.0-r0.apk
+    url = "https://web.archive.org/web/20240412082958/http://dl-cdn.alpinelinux.org/alpine/edge/testing/x86_64/proot-static-5.4.0-r0.apk";
+    sha256 = "sha256:0ljxc4waa5i1j7hcqli4z7hhpkvjr5k3xwq1qyhlm2lldmv9izqy";
+  };
+  aarch64-linux = {
+    # original: http://dl-cdn.alpinelinux.org/alpine/edge/testing/aarch64/proot-static-5.4.0-r0.apk
+    url = "https://web.archive.org/web/20240412083320/http://dl-cdn.alpinelinux.org/alpine/edge/testing/aarch64/proot-static-5.4.0-r0.apk";
+    sha256 = "sha256:0nl3gnbirxkhyralqx01xwg8nxanj1bgz7pkk118nv5wrf26igyd";
+  };
+};
+in
 pkgs.stdenv.mkDerivation {
   name = "proot";
   src = builtins.fetchurl {
-    url = "http://dl-cdn.alpinelinux.org/alpine/edge/testing/x86_64/proot-static-5.2.0_alpha-r0.apk";
+    url = apks.${system}.url;
+    sha256 = apks.${system}.sha256;
   };
   unpackPhase = ''
     tar -xf $src


### PR DESCRIPTION
- update proot to 5.4.0
- add tests for ubuntu 23.10 and 24.04
- enable proot to be tested on more distros again
