### PR TITLE
fix: remove xz compression option.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -422,7 +422,6 @@ let
     ### install nix store
     # Install all the nix store paths necessary for the current nix-portable version
     # We only unpack missing store paths from the tar archive.
-    # xz must be in PATH
     index="$(cat ${storeTar}/index)"
 
     # if [ ! "\$NP_RUNTIME" == "nix" ]; then

--- a/flake.nix
+++ b/flake.nix
@@ -172,10 +172,6 @@
             bundledPackage = drv;
             compression = "zstd -19 -T0";
           };
-          xz-max = drv: self.packages.${system}.nix-portable.override {
-            bundledPackage = drv;
-            compression = "xz -9 -T0";
-          };
         });
 
         devShell = forAllSystems (system: pkgs:


### PR DESCRIPTION
nix-portable currently does not ship xz so it could crash when executing a xz compressed bundle
