### PR TITLE
Ignore top-level sockets

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -271,7 +271,7 @@ let
       ### gather paths to bind for proot
       # we cannot bind / to / without running into a lot of trouble, therefore
       # we need to collect all top level directories and bind them inside an empty root
-      pathsTopLevel="\$(find / -mindepth 1 -maxdepth 1 -not -name nix -not -name dev)"
+      pathsTopLevel="\$(find / -mindepth 1 -maxdepth 1 -not -name nix -not -name dev -not -type s)"
 
 
       toBind=""


### PR DESCRIPTION
I was on a system with top-level directory containing administrative sockets. These caused bwrap to fail bind-mount. With this tweak sockets get ignored.

There are probably other approaches worth considering but this was the simplest solution.