### PR TITLE
Allow specifying .nix-portable name with NP_DIRNAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,8 @@ The following environment variables are optional and can be used to override the
 ```txt
 NP_DEBUG      (1 = debug msgs; 2 = 'set -x' for nix-portable)
 NP_GIT        specify path to the git executable
-NP_LOCATION   where to put the `.nix-portable` dir. (defaults to `$HOME`)
+NP_LOCATION   where to put the data dir. (defaults to `$HOME`)
+NP_DIRNAME    name of the data dir. (defaults to `.nix-portable`)
 NP_RUNTIME    which runtime to use (must be one of: nix, bwrap, proot)
 NP_NIX        specify the path to the static nix executable to use in case nix is selected as runtime
 NP_BWRAP      specify the path to the bwrap executable to use in case bwrap is selected as runtime

--- a/default.nix
+++ b/default.nix
@@ -131,8 +131,9 @@ let
 
     # user specified location for program files and nix store
     [ -z "\$NP_LOCATION" ] && NP_LOCATION="\$HOME"
+    [ -z "\$NP_DIRNAME" ] && NP_DIRNAME=".nix-portable"
     NP_LOCATION="\$(readlink -f "\$NP_LOCATION")"
-    dir="\$NP_LOCATION/.nix-portable"
+    dir="\$NP_LOCATION/\$NP_DIRNAME"
     store="\$dir/nix/store"
     # create /nix/var/nix to prevent nix from falling back to chroot store.
     mkdir -p \$dir/{bin,nix/var/nix,nix/store}


### PR DESCRIPTION
Mainly because I wanted it to be in XDG_DATA_HOME (aka. `.local/share`) which shouldn't have dotfiles. Shouldn't hurt anyone.